### PR TITLE
Fix duplicate symbol errors when compiling and update to llvm 4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OBJ = ${SOURCES:.cpp=.o}
 CC = llvm-g++
 # -stdlib=libc++ -std=c++11
 CFLAGS = -g -O3 -I llvm/include -I llvm/build/include -I ./
-LLVMFLAGS = `/usr/local/Cellar/llvm/3.9.1_1/bin/llvm-config --cxxflags --ldflags --system-libs --libs all`
+LLVMFLAGS = `/usr/local/Cellar/llvm@4/4.0.1/bin/llvm-config --cxxflags --ldflags --system-libs --libs all`
 
 .PHONY: main
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Kaleidoscope: Implementing a Language with LLVM
 
+## How to build it
+On macOS (tested on 10.11.6).
+~~~
+# Install llvm (version 4.0, though @3.9 also works if you modify the llvm path in the Makefile)
+brew install llvm@4
+make
+./main
+# This should bring up a simple repl
+~~~
+
 ## Why?
 
 Self-education...

--- a/kaleidoscope/kaleidoscope.cpp
+++ b/kaleidoscope/kaleidoscope.cpp
@@ -1,0 +1,13 @@
+#include "kaleidoscope.h"
+
+// This is an object that owns LLVM core data structures
+llvm::LLVMContext TheContext;
+
+// This is a helper object that makes easy to generate LLVM instructions
+llvm::IRBuilder<> Builder(TheContext);
+
+// This is an LLVM construct that contains functions and global variables
+std::unique_ptr<llvm::Module> TheModule;
+
+// This map keeps track of which values are defined in the current scope
+std::map<std::string, llvm::Value *> NamedValues;

--- a/kaleidoscope/kaleidoscope.h
+++ b/kaleidoscope/kaleidoscope.h
@@ -14,15 +14,15 @@
 #include "llvm/IR/Verifier.h"
 
 // This is an object that owns LLVM core data structures
-llvm::LLVMContext TheContext;
+extern llvm::LLVMContext TheContext;
 
 // This is a helper object that makes easy to generate LLVM instructions
-llvm::IRBuilder<> Builder(TheContext);
+extern llvm::IRBuilder<> Builder;
 
 // This is an LLVM construct that contains functions and global variables
-std::unique_ptr<llvm::Module> TheModule;
+extern std::unique_ptr<llvm::Module> TheModule;
 
 // This map keeps track of which values are defined in the current scope
-std::map<std::string, llvm::Value *> NamedValues;
+extern std::map<std::string, llvm::Value *> NamedValues;
 
 #endif

--- a/lexer/lexer.cpp
+++ b/lexer/lexer.cpp
@@ -1,6 +1,10 @@
 #include "lexer/lexer.h"
 #include "lexer/token.h"
 
+int CurTok;
+std::string IdentifierStr;
+double NumVal;
+
 // The actual implementation of the lexer is a single function gettok()
 // It's called to return the next token from standard input
 // gettok works by calling getchar() function to read chars one at a time

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -7,16 +7,16 @@
 // Provide a simple token buffer
 // CurTok is the current token the parser is looking at
 // getNextToken reads another token from the lexer and updates CurTok with its results
-int CurTok;
+extern int CurTok;
 int gettok();
 int getNextToken();
 
 // If the current token is an identifier
 // IdentifierStr will hold the name of the identifier
-std::string IdentifierStr;
+extern std::string IdentifierStr;
 
 // If the current token is a numeric literal
 // NumVal holds its value
-double NumVal;
+extern double NumVal;
 
 #endif

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -1,5 +1,7 @@
 #include "parser/parser.h"
 
+std::map<char, int> BinopPrecedence;
+
 static int GetTokPrecedence() {
   if (!isascii(CurTok)) {
     return -1;

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -12,7 +12,7 @@
 #include "lexer/lexer.h"
 #include "lexer/token.h"
 
-std::map<char, int> BinopPrecedence;
+extern std::map<char, int> BinopPrecedence;
 std::unique_ptr<ExprAST> ParseNumberExpr();
 std::unique_ptr<ExprAST> ParseParenExpr();
 std::unique_ptr<ExprAST> ParseIdentifierExpr();


### PR DESCRIPTION
I'm not sure how you managed to build it previously because many symbols are defined in header files which are included in multiple locations rather than being declared in header files and defined in .cpp files. Without these fixes I get a ton of errors about duplicate symbols.

Fixes #1.