### PR TITLE
Update to LLVM-15 and C++14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.o
 
 /llvm
+.vscode
+main

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,9 @@ SOURCES = $(shell find ast kaleidoscope lexer logger parser -name '*.cpp')
 HEADERS = $(shell find ast kaleidoscope lexer logger parser -name '*.h')
 OBJ = ${SOURCES:.cpp=.o}
 
-CC = llvm-g++
-# -stdlib=libc++ -std=c++11
+CC = llvm-g++ -stdlib=libc++ -std=c++14
 CFLAGS = -g -O3 -I llvm/include -I llvm/build/include -I ./
-LLVMFLAGS = `/usr/local/Cellar/llvm@4/4.0.1/bin/llvm-config --cxxflags --ldflags --system-libs --libs all`
+LLVMFLAGS = `llvm-config --cxxflags --ldflags --system-libs --libs all`
 
 .PHONY: main
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Kaleidoscope: Implementing a Language with LLVM
 
 ## How to build it
-On macOS (tested on 10.11.6).
+On MacOS (tested on Ventura 13.0).
 ~~~
-# Install llvm (version 4.0, though @3.9 also works if you modify the llvm path in the Makefile)
-brew install llvm@4
+# Install llvm (version 15.0)
+brew install llvm@15
 make
 ./main
-# This should bring up a simple repl
+# This should bring up a simple REPL.
 ~~~
 
 ## Why?
@@ -17,7 +17,7 @@ Self-education...
 I'm interested in LLVM and want to try simple things with it.
 That's why I've started official LLVM tutorial - [Kaleidoscope](http://llvm.org/docs/tutorial).
 
-## What's all about?
+## What's it all about?
 
 This tutorial runs through the implementation of a simple language, showing how fun and easy it can be.
 This tutorial will get you up and started as well as help to build a framework you can extend to other languages.

--- a/ast/FunctionAST.cpp
+++ b/ast/FunctionAST.cpp
@@ -16,7 +16,7 @@ llvm::Function *FunctionAST::codegen() {
   Builder.SetInsertPoint(BB);
   NamedValues.clear();
   for (auto &Arg : TheFunction->args()) {
-    NamedValues[Arg.getName()] = &Arg;
+    NamedValues[Arg.getName().data()] = &Arg;
   }
 
   if (llvm::Value *RetVal = Body->codegen()) {

--- a/kaleidoscope/kaleidoscope.h
+++ b/kaleidoscope/kaleidoscope.h
@@ -13,6 +13,8 @@
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Verifier.h"
 
+#include <map>
+
 // This is an object that owns LLVM core data structures
 extern llvm::LLVMContext TheContext;
 

--- a/main.cpp
+++ b/main.cpp
@@ -113,7 +113,7 @@ int main() {
   fprintf(stderr, "ready> ");
   getNextToken();
 
-  TheModule = llvm::make_unique<Module>("My awesome JIT", TheContext);
+  TheModule = std::make_unique<Module>("My awesome JIT", TheContext);
 
   MainLoop();
 

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -16,7 +16,7 @@ static int GetTokPrecedence() {
 // This routine expects to be called when the current token is a tok_number
 // It takes the current number value and creates a NumberExprAST node
 std::unique_ptr<ExprAST> ParseNumberExpr() {
-  auto Result = llvm::make_unique<NumberExprAST>(NumVal);
+  auto Result = std::make_unique<NumberExprAST>(NumVal);
   getNextToken();
   return std::move(Result);
 }
@@ -45,7 +45,7 @@ std::unique_ptr<ExprAST> ParseIdentifierExpr() {
   getNextToken();
 
   if (CurTok != '(') {
-    return llvm::make_unique<VariableExprAST>(IdName);
+    return std::make_unique<VariableExprAST>(IdName);
   }
 
   getNextToken();
@@ -72,7 +72,7 @@ std::unique_ptr<ExprAST> ParseIdentifierExpr() {
 
   getNextToken();
 
-  return llvm::make_unique<CallExprAST>(IdName, std::move(Args));
+  return std::make_unique<CallExprAST>(IdName, std::move(Args));
 }
 
 std::unique_ptr<ExprAST> ParsePrimary() {
@@ -112,7 +112,7 @@ std::unique_ptr<ExprAST> ParseBinOpRHS(int ExprPrec, std::unique_ptr<ExprAST> LH
       }
     }
 
-    LHS = llvm::make_unique<BinaryExprAST>(BinOp, std::move(LHS), std::move(RHS));
+    LHS = std::make_unique<BinaryExprAST>(BinOp, std::move(LHS), std::move(RHS));
   }
 }
 
@@ -149,7 +149,7 @@ std::unique_ptr<PrototypeAST> ParsePrototype() {
 
   getNextToken();
 
-  return llvm::make_unique<PrototypeAST>(FnName, std::move(ArgNames));
+  return std::make_unique<PrototypeAST>(FnName, std::move(ArgNames));
 }
 
 std::unique_ptr<FunctionAST> ParseDefinition() {
@@ -161,7 +161,7 @@ std::unique_ptr<FunctionAST> ParseDefinition() {
   }
 
   if (auto E = ParseExpression()) {
-    return llvm::make_unique<FunctionAST>(std::move(Proto), std::move(E));
+    return std::make_unique<FunctionAST>(std::move(Proto), std::move(E));
   }
 
   return nullptr;
@@ -169,8 +169,8 @@ std::unique_ptr<FunctionAST> ParseDefinition() {
 
 std::unique_ptr<FunctionAST> ParseTopLevelExpr() {
   if (auto E = ParseExpression()) {
-    auto Proto = llvm::make_unique<PrototypeAST>("__anon_expr", std::vector<std::string>());
-    return llvm::make_unique<FunctionAST>(std::move(Proto), std::move(E));
+    auto Proto = std::make_unique<PrototypeAST>("__anon_expr", std::vector<std::string>());
+    return std::make_unique<FunctionAST>(std::move(Proto), std::move(E));
   }
 
   return nullptr;


### PR DESCRIPTION
**Problem:**

I was curious in trying the code from the Kaleidoscope tutorial, but I ran into issues compiling it with LLVM-15 and C++14.

**Summary of this PR:**

This pull request updates the project to support LLVM-15 and C++14, which only requires a few small changes.

**Commits:**

I've split the PR into three commits:

1) Add new items to the `.gitignore` for the program binary and VSCode settings.

2) Fix compilation errors I had with locating `std::map`, and with using a `StringRef` as a key into this map instead of a `std::string`.

3) Make the required changes to support LLVM-15 and C++14. This involved updating `llvm::make_unique` to `std::make_unique` (as `llvm::make_unique` has been removed), and updating the Makefile.

**Thanks!**